### PR TITLE
Added autoload option to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,5 +3,8 @@
     "description": "Kerio APIs Client Library for PHP",
     "require": {
         "php": ">=5.3.0"
+    },
+    "autoload": {
+        "classmap": ["./"]
     }
 }


### PR DESCRIPTION
I added autoload option to composer.json for right operation of composer autoloader.

And please create tag "v1.4.0.234", then it is possible define used version in composer and it's not needed use :dev-master.